### PR TITLE
Fixing deprecation issue for jQuery 1.9 Compat

### DIFF
--- a/jQuery.printElement/jquery.printElement.js
+++ b/jQuery.printElement/jquery.printElement.js
@@ -28,7 +28,7 @@
         //iframe mode is not supported for opera and chrome 3.0 (it prints the entire page).
         //http://www.google.com/support/forum/p/Webmasters/thread?tid=2cb0f08dce8821c3&hl=en
         if (mainOptions["printMode"] == 'iframe') {
-            if ($.browser.opera || (/chrome/.test(navigator.userAgent.toLowerCase())))
+            if ((/opera/.test(navigator.userAgent.toLowerCase())) || (/chrome/.test(navigator.userAgent.toLowerCase())))
                 mainOptions["printMode"] = 'popup';
         }
         //Remove previously printed iframe if exists
@@ -173,7 +173,7 @@
         html.push('<base href="' + _getBaseHref() + '" />');
         html.push('</head><body style="' + opts["printBodyOptions"]["styleToAdd"] + '" class="' + opts["printBodyOptions"]["classNameToAdd"] + '">');
         html.push('<div class="' + $element.attr('class') + '">' + elementHtml + '</div>');
-        html.push('<script type="text/javascript">function printPage(){focus();print();' + ((!$.browser.opera && !opts["leaveOpen"] && opts["printMode"].toLowerCase() == 'popup') ? 'close();' : '') + '}</script>');
+        html.push('<script type="text/javascript">function printPage(){focus();print();' + ((!(/opera/.test(navigator.userAgent.toLowerCase())) && !opts["leaveOpen"] && opts["printMode"].toLowerCase() == 'popup') ? 'close();' : '') + '}</script>');
         html.push('</body></html>');
 
         return html.join('');


### PR DESCRIPTION
In jQuery 1.9 $.browser was finally removed completely. This script is really helpful and everything else still works with it, so I thought I'd fixed the compat issue and say thanks for writing this plugin.
